### PR TITLE
feat: add easy and hard input modes

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,22 +1,40 @@
+import { easyInputMode } from './easyInputMode'
+import { hardInputMode } from './hardInputMode'
 import { Robot } from './robot'
 import { Table } from './table'
-import { parseCommand } from './commandParser'
-import { renderRobotOnTable } from './renderRobotOnTable'
+import readline from 'readline'
 
-const readline = require('readline').createInterface({
+const rl = readline.createInterface({
   input: process.stdin,
   output: process.stdout,
+  terminal: true
 })
+
+// Make stdin emit keypress events
+readline.emitKeypressEvents(process.stdin)
+// This line is necessary to ensure that the input is not echoed
+if (process.stdin.isTTY) process.stdin.setRawMode(true)
 
 const robot = new Robot()
 const table = new Table(5, 5)
 
 function startInput() {
-  readline.question('Enter command: ', (command) => {
-    parseCommand(robot, table, command)
-    renderRobotOnTable(robot, table)
-    startInput() // prompt again
-  })
+  rl.question(
+    "Would you like to activate the easy mode for controlling the robot? [y/n]",
+    (command) => {
+      if (command === 'y') {
+        console.log('Easy mode activated. Use the arrow keys to control the robot.')
+        easyInputMode(robot, table)
+      } else if (command === 'n') {
+        console.log('Hard mode activated. Enter commands to control the robot.')
+        console.log('Valid commands are: PLACE ${x},${y},${facing}, FORWARD, REVERSE, LEFT, RIGHT, REPORT')
+        hardInputMode(robot, table, rl)
+      } else {
+        console.log('Invalid input. Please try again.')
+        startInput()
+      }
+    }
+  )
 }
 
 console.log('Toy Robot Simulator. Enter commands to control the robot:')

--- a/src/commandParser.js
+++ b/src/commandParser.js
@@ -1,7 +1,8 @@
 export const parseCommand = (robot, table, command) => {
   const parts = command.split(' ')
   const cmd = parts[0]
-
+  const newX = robot.x
+  const newY = robot.y
   switch (cmd) {
     case 'PLACE':
       const [x, y, facing] = parts[1].split(',')
@@ -9,10 +10,15 @@ export const parseCommand = (robot, table, command) => {
         robot.place(parseInt(x), parseInt(y), facing)
       }
       break
-    case 'MOVE':
-      const newX = robot.x
-      const newY = robot.y
-      robot.move()
+    case 'FORWARD':
+      robot.forward()
+      if (!table.isValidPosition(robot.x, robot.y)) {
+        robot.x = newX
+        robot.y = newY
+      }
+      break
+    case 'REVERSE':
+      robot.reverse()
       if (!table.isValidPosition(robot.x, robot.y)) {
         robot.x = newX
         robot.y = newY

--- a/src/commandParser.test.js
+++ b/src/commandParser.test.js
@@ -27,7 +27,7 @@ describe('parseCommand', () => {
 
   it('should move the robot one unit forward', () => {
     parseCommand(robot, table, 'PLACE 0,0,NORTH')
-    parseCommand(robot, table, 'MOVE')
+    parseCommand(robot, table, 'FORWARD')
     expect(robot.x).toBe(0)
     expect(robot.y).toBe(1)
     expect(robot.facing).toBe('NORTH')
@@ -35,7 +35,7 @@ describe('parseCommand', () => {
 
   it('should not move the robot if it would fall off the table', () => {
     parseCommand(robot, table, 'PLACE 0,0,SOUTH')
-    parseCommand(robot, table, 'MOVE')
+    parseCommand(robot, table, 'FORWARD')
     expect(robot.x).toBe(0)
     expect(robot.y).toBe(0)
     expect(robot.facing).toBe('SOUTH')

--- a/src/easyInputMode.js
+++ b/src/easyInputMode.js
@@ -1,0 +1,20 @@
+import { parseCommand } from './commandParser'
+import { renderRobotOnTable } from './renderRobotOnTable'
+
+export function easyInputMode(robot, table) {
+  parseCommand(robot, table, 'PLACE 0,0,NORTH')
+  renderRobotOnTable(robot, table)
+  
+  process.stdin.on('keypress', (str, key) => {
+    if (key.name === 'up') {
+      parseCommand(robot, table, 'FORWARD')
+    } else if (key.name === 'left') {
+      parseCommand(robot, table, 'LEFT')
+    } else if (key.name === 'right') {
+      parseCommand(robot, table, 'RIGHT')
+    } else if (key.name === 'down') {
+        parseCommand(robot, table, 'REVERSE')
+    }
+    renderRobotOnTable(robot, table)
+  })
+}

--- a/src/hardInputMode.js
+++ b/src/hardInputMode.js
@@ -1,0 +1,10 @@
+import { parseCommand } from './commandParser'
+import { renderRobotOnTable } from './renderRobotOnTable'
+
+export function hardInputMode(robot, table, readline) {
+  readline.question('Enter command: ', (command) => {
+    parseCommand(robot, table, command)
+    renderRobotOnTable(robot, table)
+    hardInputMode(robot, table, readline) // prompt again
+  })
+}

--- a/src/renderRobotOnTable.js
+++ b/src/renderRobotOnTable.js
@@ -1,5 +1,5 @@
 export const renderRobotOnTable = (robot, table) => {
-  let boardRepresentation = ''
+  let boardRepresentation = '\n'
 
   const arrows = {
     NORTH: '↑',

--- a/src/robot.js
+++ b/src/robot.js
@@ -12,7 +12,7 @@ export class Robot {
     this.facing = facing
   }
 
-  move() {
+  forward() {
     switch (this.facing) {
       case 'NORTH':
         this.y += 1
@@ -25,6 +25,23 @@ export class Robot {
         break
       case 'WEST':
         this.x -= 1
+        break
+    }
+  }
+
+  reverse() {
+    switch (this.facing) {
+      case 'NORTH':
+        this.y -= 1
+        break
+      case 'SOUTH':
+        this.y += 1
+        break
+      case 'EAST':
+        this.x -= 1
+        break
+      case 'WEST':
+        this.x += 1
         break
     }
   }

--- a/src/robot.test.js
+++ b/src/robot.test.js
@@ -16,10 +16,10 @@ describe('Robot', () => {
     })
   })
 
-  describe('move', () => {
+  describe('forward', () => {
     it('should move the robot one unit north when facing north', () => {
       robot.place(0, 0, 'NORTH')
-      robot.move()
+      robot.forward()
       expect(robot.x).toEqual(0)
       expect(robot.y).toEqual(1)
       expect(robot.facing).toEqual('NORTH')
@@ -27,7 +27,7 @@ describe('Robot', () => {
 
     it('should move the robot one unit south when facing south', () => {
       robot.place(0, 1, 'SOUTH')
-      robot.move()
+      robot.forward()
       expect(robot.x).toEqual(0)
       expect(robot.y).toEqual(0)
       expect(robot.facing).toEqual('SOUTH')
@@ -35,7 +35,7 @@ describe('Robot', () => {
 
     it('should move the robot one unit east when facing east', () => {
       robot.place(0, 0, 'EAST')
-      robot.move()
+      robot.forward()
       expect(robot.x).toEqual(1)
       expect(robot.y).toEqual(0)
       expect(robot.facing).toEqual('EAST')
@@ -43,7 +43,7 @@ describe('Robot', () => {
 
     it('should move the robot one unit west when facing west', () => {
       robot.place(1, 0, 'WEST')
-      robot.move()
+      robot.forward()
       expect(robot.x).toEqual(0)
       expect(robot.y).toEqual(0)
       expect(robot.facing).toEqual('WEST')


### PR DESCRIPTION
## Problem Am I Trying to Solve
1. Improve the user experience of inputting instructions to the robot. Typing out `PLACE 1,1,SOUTH`, `MOVE`, `LEFT` etc is. painful.
2. More input validation - currently, there aren't many guard rails around what can be inputted

## Solution
I thought having an "easy" and a "hard" mode would be cool. The "easy" mode should have a default starting position and then use the arrow keys to move it. The hard mode would allow a user to control it as before. In retrospect, a better name for "hard" mode would be "advanced." Given more time, I would clean this up but for consistency I will continue to refer to this as "hard" mode.

## Implementation
Ask a question in the terminal that waits for a `y` or `n` input. 
> Would you like to activate the easy mode for controlling the robot? [y/n]

Unfortunately, using up arrow when using easy mode shows the last command, `y`, above the output. This experience could be better. To solve this, I tried:
1. Clearing the command history but couldn't find a straightforward way of doing this
2. Installed a package called [Inquirer](https://github.com/SBoudrias/Inquirer.js) to ask the questions without typing
   - This created a new problem - after the question is asked the session is terminated globally and it didn't seem possible to back to `readline` to then get the arrow input
   - Inquirer doesn't make it very easy to get raw arrow keypress input... It may still be possible, but I had to make a call to not investigate futher due to time constraints. 
3. Temp low effort solve
  - To prevent the `y` from disrupting the top row I just added a new line. Before the grid is rendered

## Testing
This PR still needs to be fully unit-tested. Given the implementation uncertainties, it didn't make sense to TDD until the solution had been settled on.

## Other notes
I'm not happy about some code I introduced in the `app.js` file in this PR. The "hard" mode has to have `readline` passed into it as a param. It has to be passed in becuase having 2 instances of readline results in double button presses. Oddly enough "easy" mode doesn't need this passed in because it can get events from `process.stdin.on`. This feels weird and symmetric... some how this needs to be addressed.


## Screenshot
<img width="696" alt="Screenshot 2023-11-12 at 17 55 03" src="https://github.com/olddustysocksunderthecouch/table-robot/assets/11856857/bb2863d6-ed19-4a31-bd11-9fb88a8ccf61">
